### PR TITLE
Use configured timeout value when making requests

### DIFF
--- a/pybitx/api.py
+++ b/pybitx/api.py
@@ -65,9 +65,11 @@ class BitX:
         url = self.construct_url(call)
         auth = self.auth if kind == 'auth' else None
         if http_call == 'get':
-            response = self._requests_session.get(url, params = params, auth = auth)
+            response = self._requests_session.get(
+                url, params = params, auth = auth, timeout = self.timeout)
         elif http_call == 'post':
-            response = self._requests_session.post(url, data = params, auth = auth)
+            response = self._requests_session.post(
+                url, data = params, auth = auth, timeout = self.timeout)
         else:
             raise ValueError('Invalid http_call parameter')
         try:


### PR DESCRIPTION
The timeout value passed to the `Api` class is currently only assigned to a property of the class but never actually made use of. This change uses the value in the requests made by the class. I've had some hangs before which made me look into this. 

I may not have gotten your preferred style of multi-line code right so the PR might need some tweaks to comply with your style.